### PR TITLE
Make the majority of the Mapper's "strict" with mapping target attrib…

### DIFF
--- a/edocumentation-domain/src/main/java/org/dcsa/edocumentation/domain/persistence/entity/ConsignmentItem.java
+++ b/edocumentation-domain/src/main/java/org/dcsa/edocumentation/domain/persistence/entity/ConsignmentItem.java
@@ -35,7 +35,7 @@ public class ConsignmentItem {
   @Column(name = "hs_code", nullable = false)
   @CollectionTable(name = "hs_code_item", joinColumns = @JoinColumn(name = "consignment_item_id"))
   @OrderColumn(name = "element_order")
-  private List<String> hsCode;
+  private List<String> hsCodes;
 
   @ToString.Exclude
   @EqualsAndHashCode.Exclude

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/ReferenceService.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/ReferenceService.java
@@ -35,9 +35,7 @@ public class ReferenceService {
     if (references != null && !references.isEmpty()) {
       List<Reference> referenceDAOs =
           references.stream()
-              .map(referenceTO -> referenceMapper.toDAO(referenceTO).toBuilder()
-                .shippingInstructionID(shippingInstruction.getId())
-                .build())
+              .map(referenceTO -> referenceMapper.toDAO(referenceTO, shippingInstruction))
               .toList();
       saveReferenceDAOs(referenceDAOs);
     }

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/ActiveReeferSettingsMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/ActiveReeferSettingsMapper.java
@@ -3,9 +3,11 @@ package org.dcsa.edocumentation.service.mapping;
 import org.dcsa.edocumentation.domain.persistence.entity.ActiveReeferSettings;
 import org.dcsa.edocumentation.transferobjects.ActiveReeferSettingsTO;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", config = EDocumentationMappingConfig.class)
 public interface ActiveReeferSettingsMapper {
+  @Mapping(target = "id", ignore = true)
   ActiveReeferSettings toDAO(ActiveReeferSettingsTO activeReeferSettings);
   ActiveReeferSettingsTO toDTO(ActiveReeferSettings activeReeferSettings);
 }

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/BookingMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/BookingMapper.java
@@ -3,13 +3,18 @@ package org.dcsa.edocumentation.service.mapping;
 import org.dcsa.edocumentation.domain.persistence.entity.Booking;
 import org.dcsa.edocumentation.transferobjects.BookingRefStatusTO;
 import org.dcsa.edocumentation.transferobjects.BookingTO;
+import org.dcsa.skernel.infrastructure.services.mapping.AddressMapper;
 import org.dcsa.skernel.infrastructure.services.mapping.LocationMapper;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
 
 @Mapper(
     componentModel = "spring",
+    config = EDocumentationMappingConfig.class,
+    unmappedTargetPolicy = ReportingPolicy.WARN,  // FIXME: Remove this when we are ready to do ERROR level reporting
     uses = {
+      AddressMapper.class,
       LocationMapper.class,
       DisplayedAddressMapper.class,
       DocumentPartyMapper.class,

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/BookingSummaryMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/BookingSummaryMapper.java
@@ -5,12 +5,15 @@ import org.dcsa.edocumentation.transferobjects.BookingSummaryTO;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", config = EDocumentationMappingConfig.class)
 public interface BookingSummaryMapper {
 
   @Mapping(source = "booking.vessel.vesselIMONumber", target = "vesselIMONumber")
   @Mapping(
       source = " booking.modeOfTransport.dcsaTransportType",
       target = "preCarriageModeOfTransportCode")
+  @Mapping(target = "submissionDateTime", ignore = true)  // FIXME: Verify if this should be mapped
+  @Mapping(target = "vesselName", ignore = true)  // FIXME: Verify if this should be mapped
+  @Mapping(target = "exportVoyageNumber", ignore = true)  // FIXME: Verify if this should be mapped
   BookingSummaryTO BookingToBookingSummary(Booking booking);
 }

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/CargoItemMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/CargoItemMapper.java
@@ -5,10 +5,16 @@ import org.dcsa.edocumentation.domain.persistence.entity.UtilizedTransportEquipm
 import org.dcsa.edocumentation.transferobjects.CargoItemTO;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
 
-@Mapper(componentModel = "spring")
+@Mapper(
+  componentModel = "spring",
+  config = EDocumentationMappingConfig.class,
+  unmappedTargetPolicy = ReportingPolicy.WARN  // FIXME: Remove this line when we are ready for ERROR.
+)
 public interface CargoItemMapper {
 
+  @Mapping(target = "id", ignore = true)
   CargoItem toDAO(CargoItemTO cargoItemTO);
 
 

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/CommodityMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/CommodityMapper.java
@@ -6,7 +6,7 @@ import org.dcsa.edocumentation.transferobjects.CommodityTO;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", config = EDocumentationMappingConfig.class)
 public interface CommodityMapper {
   @Mapping(source = "booking", target = "booking")
   @Mapping(source = "booking.id", target = "id", ignore = true)

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/ConsignmentItemMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/ConsignmentItemMapper.java
@@ -9,13 +9,21 @@ import org.mapstruct.Mapping;
 
 import java.util.List;
 
-@Mapper(componentModel = "spring", uses = {
-  ReferenceMapper.class,
-  CargoItemMapper.class,
-})
+@Mapper(
+  componentModel = "spring",
+  config = EDocumentationMappingConfig.class,
+  uses = {
+    ReferenceMapper.class,
+    CargoItemMapper.class,
+    CustomsReferenceMapper.class,
+  }
+)
 public interface ConsignmentItemMapper {
 
-  @Mapping(source = "cargoItems", target = "cargoItems", ignore = true)
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "shippingInstruction", ignore = true)
+  @Mapping(target = "shipment", ignore = true)
+  @Mapping(target = "commodity", ignore = true)
   ConsignmentItem toDAO(ConsignmentItemTO consignmentItemTO);
 
   default String mapShipmentToCarrierBookingReference(Shipment shipment) {
@@ -29,5 +37,9 @@ public interface ConsignmentItemMapper {
 
   @Mapping(source = "shipment", target = "carrierBookingReference")
   @Mapping(source = "commodity", target = "hsCodes")
+  @Mapping(target = "weight", ignore = true)  // FIXME: Align DAO/TD or verify it is not necessary and remove FIXME
+  @Mapping(target = "weightUnit", ignore = true)  // FIXME: Align DAO/TD or verify it is not necessary and remove FIXME
+  @Mapping(target = "volume", ignore = true)  // FIXME: Align DAO/TD or verify it is not necessary and remove FIXME
+  @Mapping(target = "volumeUnit", ignore = true)  // FIXME: Align DAO/TD or verify it is not necessary and remove FIXME
   ConsignmentItemTO toDTO(ConsignmentItem consignmentItem);
 }

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/CustomsReferenceMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/CustomsReferenceMapper.java
@@ -1,0 +1,18 @@
+package org.dcsa.edocumentation.service.mapping;
+
+import org.dcsa.edocumentation.domain.persistence.entity.CustomsReference;
+import org.dcsa.edocumentation.transferobjects.CustomsReferenceTO;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(
+  componentModel = "spring",
+  config = EDocumentationMappingConfig.class
+)
+public interface CustomsReferenceMapper {
+  @Mapping(target = "referenceID", ignore = true)
+  @Mapping(target = "utilizedTransportEquipment", ignore = true)
+  @Mapping(target = "shippingInstruction", ignore = true)
+  @Mapping(target = "consignmentItem", ignore = true)
+  CustomsReference toDAO(CustomsReferenceTO customsReferenceTO);
+}

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/DocumentPartyMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/DocumentPartyMapper.java
@@ -2,23 +2,28 @@ package org.dcsa.edocumentation.service.mapping;
 
 import org.dcsa.edocumentation.domain.persistence.entity.*;
 import org.dcsa.edocumentation.transferobjects.DocumentPartyTO;
+import org.dcsa.skernel.infrastructure.services.mapping.AddressMapper;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring", uses = {
-  DisplayedAddressMapper.class
+@Mapper(
+  componentModel = "spring",
+  config = EDocumentationMappingConfig.class,
+  uses = {
+    DisplayedAddressMapper.class,
+    PartyMapper.class,
 })
 public interface DocumentPartyMapper {
 
-  //ToDO can be removed when booking takes the same approach as Shipping instruction for setting the FK
   @Mapping(source = "booking", target = "booking")
   @Mapping(source = "booking.id", target = "id", ignore = true)
   @Mapping(source = "documentPartyTO.displayedAddress", target = "displayedAddress", ignore = true)
-  @Mapping(source = "documentPartyTO.party", target = "party", ignore = true)
+  @Mapping(target = "shippingInstructionID", ignore = true)
   DocumentParty toDAO(DocumentPartyTO documentPartyTO, Booking booking);
 
-  @Mapping(source = "documentPartyTO.displayedAddress", target = "displayedAddress", ignore = true)
-  DocumentParty toDAO(DocumentPartyTO documentPartyTO);
+  default DocumentParty toDAO(DocumentPartyTO documentPartyTO) {
+    return this.toDAO(documentPartyTO, null);
+  }
 
   @Mapping(
     target = "displayedAddress"

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/DocumentStatusMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/DocumentStatusMapper.java
@@ -5,7 +5,7 @@ import org.dcsa.edocumentation.transferobjects.enums.EblDocumentStatus;
 import org.dcsa.edocumentation.transferobjects.enums.ShipmentLocationTypeCode;
 import org.mapstruct.Mapper;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", config = EDocumentationMappingConfig.class)
 public interface DocumentStatusMapper {
   org.dcsa.edocumentation.domain.persistence.entity.enums.BkgDocumentStatus toDomainBkgDocumentStatus(BkgDocumentStatus documentStatus);
   org.dcsa.edocumentation.domain.persistence.entity.enums.EblDocumentStatus toDomainEblDocumentStatus(EblDocumentStatus documentStatus);

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/EDocumentationMappingConfig.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/EDocumentationMappingConfig.java
@@ -1,0 +1,7 @@
+package org.dcsa.edocumentation.service.mapping;
+
+import org.mapstruct.MapperConfig;
+import org.mapstruct.ReportingPolicy;
+
+@MapperConfig(unmappedTargetPolicy = ReportingPolicy.ERROR)
+public interface EDocumentationMappingConfig {}

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/EquipmentAssignmentMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/EquipmentAssignmentMapper.java
@@ -4,11 +4,13 @@ import org.dcsa.edocumentation.domain.persistence.entity.Equipment;
 import org.dcsa.edocumentation.domain.persistence.entity.unofficial.EquipmentAssignment;
 import org.dcsa.edocumentation.transferobjects.unofficial.EquipmentAssignmentTO;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 import java.util.List;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", config = EDocumentationMappingConfig.class)
 public interface EquipmentAssignmentMapper {
 
+  @Mapping(target = "ipments", ignore = true)  // FIXME: I do not know why the mapper "sees" an "ipments" attribute.
   EquipmentAssignment toDAO(EquipmentAssignmentTO equipmentAssignmentTO, List<Equipment> equipments);
 }

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/EquipmentMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/EquipmentMapper.java
@@ -7,7 +7,7 @@ import org.mapstruct.Mapper;
 
 import java.util.stream.Stream;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", config = EDocumentationMappingConfig.class)
 public interface EquipmentMapper {
   Equipment toDAO(EquipmentTO equipmentTO);
 

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/ModeOfTransportMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/ModeOfTransportMapper.java
@@ -3,7 +3,7 @@ package org.dcsa.edocumentation.service.mapping;
 import org.dcsa.edocumentation.domain.persistence.entity.enums.DCSATransportType;
 import org.mapstruct.Mapper;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", config = EDocumentationMappingConfig.class)
 public interface ModeOfTransportMapper {
   DCSATransportType toDAO(org.dcsa.edocumentation.transferobjects.enums.DCSATransportType transportType);
   org.dcsa.edocumentation.transferobjects.enums.DCSATransportType toTO(DCSATransportType transportType);

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/PartyContactDetailsMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/PartyContactDetailsMapper.java
@@ -1,0 +1,16 @@
+package org.dcsa.edocumentation.service.mapping;
+
+import org.dcsa.edocumentation.domain.persistence.entity.PartyContactDetails;
+import org.dcsa.edocumentation.transferobjects.PartyContactDetailsTO;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(
+  componentModel = "spring",
+  config = EDocumentationMappingConfig.class
+)
+public interface PartyContactDetailsMapper {
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "party", ignore = true)
+  PartyContactDetails toDAO(PartyContactDetailsTO partyContactDetailsTO);
+}

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/PartyIdentifyingCodeMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/PartyIdentifyingCodeMapper.java
@@ -1,0 +1,16 @@
+package org.dcsa.edocumentation.service.mapping;
+
+import org.dcsa.edocumentation.domain.persistence.entity.PartyIdentifyingCode;
+import org.dcsa.edocumentation.transferobjects.PartyIdentifyingCodeTO;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(
+  componentModel = "spring",
+  config = EDocumentationMappingConfig.class
+)
+public interface PartyIdentifyingCodeMapper {
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "party", ignore = true)
+  PartyIdentifyingCode toDAO(PartyIdentifyingCodeTO partyContactDetailsTO);
+}

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/PartyMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/PartyMapper.java
@@ -10,11 +10,18 @@ import org.dcsa.skernel.infrastructure.services.mapping.AddressMapper;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring", uses = AddressMapper.class)
+@Mapper(componentModel = "spring",
+  config = EDocumentationMappingConfig.class,
+  uses = {
+    AddressMapper.class,
+    PartyContactDetailsMapper.class,
+    PartyIdentifyingCodeMapper.class,
+  })
 public interface PartyMapper {
   @Mapping(source = "address", target = "address", ignore = true)
   @Mapping(source = "partyContactDetails", target = "partyContactDetails", ignore = true)
   @Mapping(source = "identifyingCodes", target = "identifyingCodes", ignore = true)
+  @Mapping(target = "id", ignore = true)
   Party toDAO(PartyTO partyTo);
   PartyTO toTO(Party party);
 

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/ReferenceMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/ReferenceMapper.java
@@ -1,17 +1,36 @@
 package org.dcsa.edocumentation.service.mapping;
 
 import org.dcsa.edocumentation.domain.persistence.entity.Booking;
+import org.dcsa.edocumentation.domain.persistence.entity.ConsignmentItem;
 import org.dcsa.edocumentation.domain.persistence.entity.Reference;
+import org.dcsa.edocumentation.domain.persistence.entity.ShippingInstruction;
 import org.dcsa.edocumentation.transferobjects.ReferenceTO;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring")
+import java.awt.print.Book;
+
+@Mapper(componentModel = "spring", config = EDocumentationMappingConfig.class)
 public interface ReferenceMapper {
 
-  //TODO can be removed if using the same setup as Shipping insteruction
   @Mapping(source = "booking", target = "booking")
-  Reference toDAO(ReferenceTO referenceTO, Booking booking);
+  @Mapping(source = "shippingInstruction.id", target = "shippingInstructionID")
+  @Mapping(target = "referenceID", ignore = true)
+  Reference toDAO(ReferenceTO referenceTO, Booking booking, ShippingInstruction shippingInstruction, ConsignmentItem consignmentItem);
 
-  Reference toDAO(ReferenceTO referenceTO);
+  default Reference toDAO(ReferenceTO referenceTO, Booking booking) {
+    return toDAO(referenceTO, booking, null, null);
+  }
+
+  default Reference toDAO(ReferenceTO referenceTO, ShippingInstruction shippingInstruction) {
+    return toDAO(referenceTO, null, shippingInstruction, null);
+  }
+
+  default Reference toDAO(ReferenceTO referenceTO, ConsignmentItem consignmentItem) {
+    return toDAO(referenceTO, null, null, consignmentItem);
+  }
+
+  default Reference toDAO(ReferenceTO referenceTO) {
+    return toDAO(referenceTO, null, null, null);
+  }
 }

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/RequestedEquipmentGroupMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/RequestedEquipmentGroupMapper.java
@@ -8,9 +8,12 @@ import org.dcsa.edocumentation.domain.persistence.entity.RequestedEquipmentGroup
 import org.dcsa.edocumentation.transferobjects.RequestedEquipmentTO;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
 
 @Mapper(
   componentModel = "spring",
+  config = EDocumentationMappingConfig.class,
+  unmappedTargetPolicy = ReportingPolicy.WARN,  // FIXME: Remove when we are ready to make this an ERROR
   uses = {
     ActiveReeferSettingsMapper.class
   }
@@ -22,6 +25,11 @@ public interface RequestedEquipmentGroupMapper {
   @Mapping(source = "requestedEquipment.isoEquipmentCode", target = "requestedEquipmentIsoEquipmentCode")
   @Mapping(source = "requestedEquipment.units", target = "requestedEquipmentUnits")
   @Mapping(source = "commodity", target = "commodity")
+  // These are not provided at this stage
+  @Mapping(target = "confirmedEquipmentUnits", ignore = true)
+  @Mapping(target = "confirmedEquipmentIsoEquipmentCode", ignore = true)
+  @Mapping(target = "shipment", ignore = true)
+  @Mapping(target = "utilizedTransportEquipments", ignore = true)
   RequestedEquipmentGroup toDAO(
     RequestedEquipmentTO requestedEquipment,
     Booking booking,

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/SealMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/SealMapper.java
@@ -3,13 +3,15 @@ package org.dcsa.edocumentation.service.mapping;
 import org.dcsa.edocumentation.domain.persistence.entity.Seal;
 import org.dcsa.edocumentation.transferobjects.SealTO;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 import java.util.UUID;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", config = EDocumentationMappingConfig.class)
 public interface SealMapper {
 
-  Seal toDAO(SealTO sealTO, UUID utilizedTransportEquipmentID);
+  @Mapping(target = "id", ignore = true)
+  Seal toDAO(SealTO sealTO);
 
   SealTO toDTO(Seal seal);
 }

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/ServiceMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/ServiceMapper.java
@@ -4,7 +4,7 @@ import org.dcsa.edocumentation.domain.persistence.entity.Service;
 import org.dcsa.edocumentation.transferobjects.ServiceTO;
 import org.mapstruct.Mapper;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", config = EDocumentationMappingConfig.class)
 public interface ServiceMapper {
   ServiceTO toDTO(Service service);
 }

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/ShipmentLocationMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/ShipmentLocationMapper.java
@@ -9,12 +9,13 @@ import org.dcsa.skernel.infrastructure.services.mapping.LocationMapper;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring", uses = LocationMapper.class)
+@Mapper(componentModel = "spring", config = EDocumentationMappingConfig.class, uses = LocationMapper.class)
 public interface ShipmentLocationMapper {
 
   @Mapping(target = "id", ignore = true) /* It defaults to pulling booking.getId(), which is wrong */
   // Needed to force the argument rather than shipmentLocationTO.location()
   @Mapping(source = "location", target = "location")
+  @Mapping(target = "shipment", ignore = true)
   ShipmentLocation toDAO(ShipmentLocationTO shipmentLocationTO, Location location, Booking booking);
 
   @Mapping(target = "id", ignore = true) /* It defaults to pulling booking.getId(), which is wrong */

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/ShipmentMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/ShipmentMapper.java
@@ -8,13 +8,16 @@ import org.dcsa.skernel.infrastructure.services.mapping.LocationMapper;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
 
 @Mapper(componentModel = "spring",
   injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+  unmappedTargetPolicy = ReportingPolicy.WARN,  // FIXME; Remove this line when we can migrate to ERROR
+  config = EDocumentationMappingConfig.class,
   uses = {LocationMapper.class,DocumentStatusMapper.class, BookingMapper.class, TransportMapper.class})
 public interface ShipmentMapper {
   @Mapping(source = "shipmentTransports", target = "transports")
-   ShipmentTO shipmentToShipmentTO(Shipment shipment);
+  ShipmentTO shipmentToShipmentTO(Shipment shipment);
 
   @Mapping(source = "shipment.booking.bookingRequestUpdatedDateTime", target = "bookingRequestUpdatedDateTime")
   @Mapping(source = "shipment.booking.bookingRequestCreatedDateTime", target = "bookingRequestCreatedDateTime")

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/ShipmentSummaryMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/ShipmentSummaryMapper.java
@@ -5,7 +5,7 @@ import org.dcsa.edocumentation.transferobjects.ShipmentSummaryTO;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", config = EDocumentationMappingConfig.class)
 public interface ShipmentSummaryMapper {
   @Mapping(
       source = "booking.carrierBookingRequestReference",

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/ShipmentTransportMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/ShipmentTransportMapper.java
@@ -7,7 +7,7 @@ import org.dcsa.skernel.domain.persistence.entity.Location;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", config = EDocumentationMappingConfig.class)
 public interface ShipmentTransportMapper {
 
   // Required to make the mapper use the argument rather than throwing it away

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/ShippingInstructionMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/ShippingInstructionMapper.java
@@ -1,31 +1,32 @@
 package org.dcsa.edocumentation.service.mapping;
 
+import java.util.List;
+import java.util.Set;
 import org.dcsa.edocumentation.domain.persistence.entity.CargoItem;
 import org.dcsa.edocumentation.domain.persistence.entity.ConsignmentItem;
-import org.dcsa.edocumentation.domain.persistence.entity.Shipment;
 import org.dcsa.edocumentation.domain.persistence.entity.ShippingInstruction;
 import org.dcsa.edocumentation.transferobjects.ShippingInstructionRefStatusTO;
 import org.dcsa.edocumentation.transferobjects.ShippingInstructionTO;
 import org.dcsa.edocumentation.transferobjects.UtilizedTransportEquipmentTO;
+import org.dcsa.skernel.infrastructure.services.mapping.AddressMapper;
 import org.dcsa.skernel.infrastructure.services.mapping.LocationMapper;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-
 @Component
 @Mapper(componentModel = "spring",
+  config = EDocumentationMappingConfig.class,
   uses = {
     LocationMapper.class,
     DisplayedAddressMapper.class,
     ReferenceMapper.class,
     DocumentPartyMapper.class,
     ConsignmentItemMapper.class,
-    DisplayedAddressMapper.class
+    DisplayedAddressMapper.class,
+    AddressMapper.class,
+    CustomsReferenceMapper.class,
   })
 public abstract class ShippingInstructionMapper {
 
@@ -34,10 +35,21 @@ public abstract class ShippingInstructionMapper {
 
   @Mapping(source = "documentParties", target = "documentParties", ignore = true)
   @Mapping(source = "consignmentItems", target = "consignmentItems", ignore = true)
+  @Mapping(target = "placeOfIssue.id", ignore = true)  // FIXME: We need a TO -> DAO location mapper
+  @Mapping(target = "placeOfIssue.facility", ignore = true)  // FIXME: We need a TO -> DAO location mapper
+  @Mapping(target = "amendmentToTransportDocument", ignore = true)  // FIXME: Align DAO/TD or verify it is not necessary and remove FIXME!
+  // Internal details; should not be mapped
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "isNew", ignore = true)
+  @Mapping(target = "validUntil", ignore = true)
+  @Mapping(target = "dfa", ignore = true)
   public abstract ShippingInstruction toDAO(ShippingInstructionTO shippingInstructionTO);
 
   // TODO: Complete this stub mapping (DDT-1296)
   @Mapping(source = "consignmentItems", target = "utilizedTransportEquipments")
+  @Mapping(target = "amendmentToTransportDocument", ignore = true)  // FIXME: We should be mapping this.
+  @Mapping(target = "areChargesDisplayedOnOriginals", ignore = true)  // FIXME: DAO/TO should be aligned here
+  @Mapping(target = "areChargesDisplayedOnCopies", ignore = true)  // FIXME: DAO/TO should be aligned here
   public abstract ShippingInstructionTO toDTO(ShippingInstruction shippingInstruction);
 
   protected List<UtilizedTransportEquipmentTO> mapConsignmentItemSetToUtilizedTransportEquipmentTOList(Set<ConsignmentItem> consignmentItemSet) {

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/ShippingInstructionSummaryMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/ShippingInstructionSummaryMapper.java
@@ -8,11 +8,14 @@ import org.mapstruct.Mapping;
 
 @Mapper(
     componentModel = "spring",
+    config = EDocumentationMappingConfig.class,
     uses = {DisplayedAddressMapper.class})
 public interface ShippingInstructionSummaryMapper {
   @Mapping(
     source = "consignmentItems",
     target = "carrierBookingReferences")
+  @Mapping(target = "amendToTransportDocument", ignore = true)  // FIXME: amendToTransportDocument should be mapped!
+  @Mapping(target = "areChargesDisplayedOnOriginals", ignore = true)  // Not in the swagger entity
   ShippingInstructionSummaryTO shippingInstructionToShippingInstructionSummary(ShippingInstruction shippingInstruction);
 
   default String mapShipmentToCarrierBookingReference(ConsignmentItem consignmentItem) {

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/TransportDocumentSummaryMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/TransportDocumentSummaryMapper.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 @Mapper(
     componentModel = "spring",
-    unmappedTargetPolicy = ReportingPolicy.IGNORE,
+    config = EDocumentationMappingConfig.class,
     uses = {PartyMapper.class})
 public abstract class TransportDocumentSummaryMapper {
 
@@ -24,6 +24,12 @@ public abstract class TransportDocumentSummaryMapper {
         @Mapping(
             target = "documentStatus",
             source = "transportDocument.shippingInstruction.documentStatus"),
+        @Mapping(
+          target = "numberOfOriginalsWithCharges",
+          source = "transportDocument.shippingInstruction.numberOfOriginalsWithCharges"),
+        @Mapping(
+          target = "numberOfOriginalsWithoutCharges",
+          source = "transportDocument.shippingInstruction.numberOfOriginalsWithoutCharges"),
         @Mapping(target = "shippedOnBoardDate", source = "shippedOnBoardDate"),
         @Mapping(target = "carrierCode", source = "transportDocument"),
         @Mapping(target = "carrierCodeListProvider", source = "transportDocument"),

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/TransportMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/TransportMapper.java
@@ -8,11 +8,13 @@ import org.mapstruct.Mapping;
 
 @Mapper(
     componentModel = "spring",
+    config = EDocumentationMappingConfig.class,
     uses = {LocationMapper.class, DocumentStatusMapper.class, ModeOfTransportMapper.class})
 public interface TransportMapper {
 
   @Mapping(
     source = "transportPlanStageCode",
     target = "transportPlanStage")
+  @Mapping(target = "isUnderShippersResponsibility", ignore = true)  // FIXME: Verify if this should be mapped
   TransportTO shipmentTransportToTransportTO(ShipmentTransport shipmentTransport);
 }

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/UtilizedTransportEquipmentMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/UtilizedTransportEquipmentMapper.java
@@ -6,16 +6,31 @@ import org.dcsa.edocumentation.transferobjects.UtilizedTransportEquipmentTO;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring", uses = {
-  ActiveReeferSettingsMapper.class,
-  EquipmentMapper.class,
-  SealMapper.class
+@Mapper(componentModel = "spring",
+  config = EDocumentationMappingConfig.class,
+  uses = {
+    ActiveReeferSettingsMapper.class,
+    EquipmentMapper.class,
+    SealMapper.class,
+    CustomsReferenceMapper.class,
+    ReferenceMapper.class,
 })
 public interface UtilizedTransportEquipmentMapper {
 
   @Mapping(source = "utilizedTransportEquipmentTO.isShipperOwned", target = "isShipperOwned")
   @Mapping(source = "equipment", target = "equipment")
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "requestedEquipmentGroup", ignore = true)
   UtilizedTransportEquipment toDAO(UtilizedTransportEquipmentTO utilizedTransportEquipmentTO, Equipment equipment);
 
+  @Mapping(target = "equipmentReference", expression = "java(null)")  // FIXME: In TD, always absent. In other cases, conditional on "isSOC"!
+  @Mapping(target = "references", ignore = true)  // FIXME: Missing on the DAO
+  // FIXME: I think these need to be mappined depending on the case (input/request vs. output/response mapping)
+  @Mapping(target = "cargoGrossVolume", ignore = true)
+  @Mapping(target = "cargoGrossVolumeUnit", ignore = true)
+  @Mapping(target = "numberOfPackages", ignore = true)
+  @Mapping(target = "isNonOperatingReefer", ignore = true)
+  @Mapping(target = "activeReeferSettings", ignore = true)
   UtilizedTransportEquipmentTO toDTO(UtilizedTransportEquipment utilizedTransportEquipment);
+
 }

--- a/edocumentation-service/src/test/java/org/dcsa/edocumentation/service/BookingServiceTest.java
+++ b/edocumentation-service/src/test/java/org/dcsa/edocumentation/service/BookingServiceTest.java
@@ -1,5 +1,18 @@
 package org.dcsa.edocumentation.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
 import org.dcsa.edocumentation.datafactories.BookingDataFactory;
 import org.dcsa.edocumentation.datafactories.LocationDataFactory;
 import org.dcsa.edocumentation.datafactories.VesselDataFactory;
@@ -33,20 +46,6 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.time.OffsetDateTime;
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 @ExtendWith(MockitoExtension.class)
 class BookingServiceTest {
   @Nested
@@ -55,6 +54,8 @@ class BookingServiceTest {
 
     @Spy private BookingMapper bookingMapper = Mappers.getMapper(BookingMapper.class);
     @Spy private AddressMapper addressMapper = Mappers.getMapper(AddressMapper.class);
+
+    @Spy private PartyMapper partyMapper = Mappers.getMapper(PartyMapper.class);
 
     @Spy private DocumentPartyMapper documentPartyMapper = Mappers.getMapper(DocumentPartyMapper.class);
     @Spy private RequestedEquipmentGroupMapper requestedEquipmentGroupMapper = Mappers.getMapper(RequestedEquipmentGroupMapper.class);
@@ -71,6 +72,8 @@ class BookingServiceTest {
       ReflectionTestUtils.setField(bookingMapper, "requestedEquipmentGroupMapper", requestedEquipmentGroupMapper);
       ReflectionTestUtils.setField(requestedEquipmentGroupMapper, "activeReeferSettingsMapper", activeReeferSettingsMapper);
       ReflectionTestUtils.setField(documentPartyMapper, "displayedAddressMapper", displayedAddressMapper);
+      ReflectionTestUtils.setField(documentPartyMapper, "partyMapper", partyMapper);
+      ReflectionTestUtils.setField(partyMapper, "addressMapper", addressMapper);
     }
 
     @Test
@@ -132,6 +135,8 @@ class BookingServiceTest {
 
     @Mock private BookingRepository bookingRepository;
     @Mock private ShipmentEventRepository shipmentEventRepository;
+
+    @Spy private AddressMapper addressMapper = Mappers.getMapper(AddressMapper.class);
     @Spy private BookingMapper bookingMapper = Mappers.getMapper(BookingMapper.class);
     @SuppressWarnings({"unused"}) /* It gets auto-injected */
     @Spy private ModeOfTransportMapper modeOfTransportMapper = Mappers.getMapper(ModeOfTransportMapper.class);
@@ -140,6 +145,7 @@ class BookingServiceTest {
 
     @BeforeEach
     public void resetMocks() {
+      ReflectionTestUtils.setField(bookingMapper, "addressMapper", addressMapper);
       reset(locationService, voyageService, vesselService, commodityService,
         requestedEquipmentGroupService, referenceService, documentPartyService, shipmentLocationService,
         bookingRepository, shipmentEventRepository);

--- a/edocumentation-service/src/test/java/org/dcsa/edocumentation/service/DocumentPartyServiceTest.java
+++ b/edocumentation-service/src/test/java/org/dcsa/edocumentation/service/DocumentPartyServiceTest.java
@@ -1,5 +1,10 @@
 package org.dcsa.edocumentation.service;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.Collections;
+import java.util.List;
 import org.dcsa.edocumentation.datafactories.BookingDataFactory;
 import org.dcsa.edocumentation.datafactories.DocumentPartyDataFactory;
 import org.dcsa.edocumentation.datafactories.ShippingInstructionDataFactory;
@@ -24,12 +29,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.Collections;
-import java.util.List;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class DocumentPartyServiceTest {
@@ -54,6 +54,7 @@ class DocumentPartyServiceTest {
 
   @BeforeEach
   public void resetMocks() {
+    ReflectionTestUtils.setField(documentPartyMapper, "partyMapper", partyMapper);
     reset(
         addressService,
         documentPartyRepository,

--- a/edocumentation-service/src/test/java/org/dcsa/edocumentation/service/ReferenceServiceTest.java
+++ b/edocumentation-service/src/test/java/org/dcsa/edocumentation/service/ReferenceServiceTest.java
@@ -41,7 +41,7 @@ class ReferenceServiceTest {
     referenceService.createReferences(null, (Booking) null);
 
     verify(referenceRepository, never()).saveAll(any());
-    verify(referenceMapper, never()).toDAO(any(), any());
+    verify(referenceMapper, never()).toDAO(any(), any(Booking.class));
   }
 
   @Test
@@ -49,7 +49,7 @@ class ReferenceServiceTest {
     referenceService.createReferences(null, (ShippingInstruction) null);
 
     verify(referenceRepository, never()).saveAll(any());
-    verify(referenceMapper, never()).toDAO(any(), any());
+    verify(referenceMapper, never()).toDAO(any(), any(ShippingInstruction.class));
   }
 
   @Test
@@ -57,7 +57,7 @@ class ReferenceServiceTest {
     referenceService.createReferences(Collections.emptyList(), (Booking) null);
 
     verify(referenceRepository, never()).saveAll(any());
-    verify(referenceMapper, never()).toDAO(any(), any());
+    verify(referenceMapper, never()).toDAO(any(), any(Booking.class));
   }
 
   @Test
@@ -65,7 +65,7 @@ class ReferenceServiceTest {
     referenceService.createReferences(Collections.emptyList(), (ShippingInstruction) null);
 
     verify(referenceRepository, never()).saveAll(any());
-    verify(referenceMapper, never()).toDAO(any(), any());
+    verify(referenceMapper, never()).toDAO(any(), any(ShippingInstruction.class));
   }
 
   @Test
@@ -98,7 +98,7 @@ class ReferenceServiceTest {
     referenceService.createReferences(List.of(referenceTO), shippingInstruction);
 
     // Verify
-    verify(referenceMapper).toDAO(referenceTO);
+    verify(referenceMapper).toDAO(referenceTO, shippingInstruction);
     verify(referenceRepository).saveAll(List.of(reference));
   }
 }

--- a/edocumentation-service/src/test/java/org/dcsa/edocumentation/service/StuffingServiceTest.java
+++ b/edocumentation-service/src/test/java/org/dcsa/edocumentation/service/StuffingServiceTest.java
@@ -36,11 +36,11 @@ class StuffingServiceTest {
   @Mock private CommodityRepository commodityRepository;
   @Mock private ConsignementItemRepository consignementItemRepository;
 
+
+  @Spy private CargoItemMapper cargoItemMapper = Mappers.getMapper(CargoItemMapper.class);
   @Spy
   private ConsignmentItemMapper consignmentItemMapper =
       Mappers.getMapper(ConsignmentItemMapper.class);
-
-  @Spy private CargoItemMapper cargoItemMapper = Mappers.getMapper(CargoItemMapper.class);
   @Spy private EquipmentMapper equipmentMapper = Mappers.getMapper(EquipmentMapper.class);
 
   @InjectMocks private StuffingService stuffingService;
@@ -58,6 +58,7 @@ class StuffingServiceTest {
   @BeforeEach
   void init() {
     ReflectionTestUtils.setField(utilizedTransportEquipmentMapper, "equipmentMapper", equipmentMapper);
+    ReflectionTestUtils.setField(consignmentItemMapper, "cargoItemMapper", cargoItemMapper);
     shippingInstruction = ShippingInstructionDataFactory.singleShallowShippingInstruction();
     savedUtilizedTransportEquipments =
         UtilizedTransportEquipmentEquipmentDataFactory.multipleCarrierOwned().stream()

--- a/edocumentation-service/src/test/java/org/dcsa/edocumentation/service/TransportDocumentServiceTest.java
+++ b/edocumentation-service/src/test/java/org/dcsa/edocumentation/service/TransportDocumentServiceTest.java
@@ -9,6 +9,7 @@ import org.dcsa.edocumentation.datafactories.TransportDocumentDataFactory;
 import org.dcsa.edocumentation.domain.persistence.entity.TransportDocument;
 import org.dcsa.edocumentation.domain.persistence.repository.TransportDocumentRepository;
 import org.dcsa.edocumentation.service.mapping.ConsignmentItemMapper;
+import org.dcsa.edocumentation.service.mapping.DisplayedAddressMapper;
 import org.dcsa.edocumentation.service.mapping.TransportDocumentMapper;
 import org.dcsa.edocumentation.transferobjects.TransportDocumentTO;
 import org.dcsa.skernel.infrastructure.services.mapping.LocationMapper;
@@ -31,6 +32,8 @@ class TransportDocumentServiceTest {
 
   @Mock ConsignmentItemMapper consignmentItemMapper;
 
+  @Mock DisplayedAddressMapper displayedAddressMapper;
+
   @Spy
   TransportDocumentMapper transportDocumentMapper =
       Mappers.getMapper(TransportDocumentMapper.class);
@@ -42,6 +45,7 @@ class TransportDocumentServiceTest {
     ReflectionTestUtils.setField(transportDocumentMapper, "locationMapper", locationMapper);
     ReflectionTestUtils.setField(transportDocumentMapper, "locMapper", locationMapper);
     ReflectionTestUtils.setField(transportDocumentMapper, "consignmentItemMapper", consignmentItemMapper);
+    ReflectionTestUtils.setField(transportDocumentMapper, "displayedAddressMapper", displayedAddressMapper);
   }
 
   @Test

--- a/edocumentation-service/src/test/java/org/dcsa/edocumentation/service/UtilizedTransportEquipmentTest.java
+++ b/edocumentation-service/src/test/java/org/dcsa/edocumentation/service/UtilizedTransportEquipmentTest.java
@@ -5,6 +5,7 @@ import org.dcsa.edocumentation.datafactories.UtilizedTransportEquipmentEquipment
 import org.dcsa.edocumentation.domain.persistence.entity.Equipment;
 import org.dcsa.edocumentation.domain.persistence.repository.UtilizedTransportEquipmentRepository;
 import org.dcsa.edocumentation.service.mapping.EquipmentMapper;
+import org.dcsa.edocumentation.service.mapping.SealMapper;
 import org.dcsa.edocumentation.service.mapping.UtilizedTransportEquipmentMapper;
 import org.dcsa.edocumentation.transferobjects.EquipmentTO;
 import org.dcsa.edocumentation.transferobjects.UtilizedTransportEquipmentTO;
@@ -42,6 +43,7 @@ class UtilizedTransportEquipmentTest {
       Mappers.getMapper(UtilizedTransportEquipmentMapper.class);
 
   @Spy EquipmentMapper equipmentMapper = Mappers.getMapper(EquipmentMapper.class);
+  @Spy SealMapper sealMapper = Mappers.getMapper(SealMapper.class);
 
   @InjectMocks UtilizedTransportEquipmentService utilizedTransportEquipmentService;
 
@@ -49,7 +51,9 @@ class UtilizedTransportEquipmentTest {
 
   @BeforeEach
   void setup() {
+
     ReflectionTestUtils.setField(utilizedTransportEquipmentMapper, "equipmentMapper", equipmentMapper);
+    ReflectionTestUtils.setField(utilizedTransportEquipmentMapper, "sealMapper", sealMapper);
   }
 
   @Test

--- a/edocumentation-transfer-obj/src/main/java/org/dcsa/edocumentation/transferobjects/ShippingInstructionSummaryTO.java
+++ b/edocumentation-transfer-obj/src/main/java/org/dcsa/edocumentation/transferobjects/ShippingInstructionSummaryTO.java
@@ -47,7 +47,7 @@ public record ShippingInstructionSummaryTO(
   @JsonAlias({"numberOfOriginals", "requestedNumberOfOriginals"})
   Integer numberOfOriginalsWithCharges,
 
-  Integer numberOfOriginalsWithOutCharges,
+  Integer numberOfOriginalsWithoutCharges,
 
   @NotNull(message = "The boolean attribute isElectronic is required.")
   boolean isElectronic,

--- a/edocumentation-transfer-obj/src/main/java/org/dcsa/edocumentation/transferobjects/ShippingInstructionTO.java
+++ b/edocumentation-transfer-obj/src/main/java/org/dcsa/edocumentation/transferobjects/ShippingInstructionTO.java
@@ -1,20 +1,15 @@
 package org.dcsa.edocumentation.transferobjects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.Min;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import java.time.OffsetDateTime;
+import java.util.List;
 import lombok.Builder;
 import org.dcsa.edocumentation.transferobjects.enums.EblDocumentStatus;
 import org.dcsa.edocumentation.transferobjects.enums.TransportDocumentTypeCode;
 import org.dcsa.skernel.infrastructure.transferobject.LocationTO;
 import org.dcsa.skernel.infrastructure.validation.RequiredIfFalse;
-
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
-import java.time.OffsetDateTime;
-import java.util.List;
-import java.util.UUID;
 
 @RequiredIfFalse(
   ifFalse = "isElectronic",
@@ -26,9 +21,6 @@ import java.util.UUID;
   }
 )
 public record ShippingInstructionTO(
-  @Size(max = 35)
-  String carrierBookingReference,
-
   @Size(max = 100)
   @JsonProperty(access = JsonProperty.Access.READ_ONLY)
   String shippingInstructionReference,
@@ -82,7 +74,9 @@ public record ShippingInstructionTO(
   @Size(max = 5)
   List<@Size(max = 35) String> displayedNameForPlaceOfDelivery,
 
-  UUID amendmentToTransportDocument,
+  @Size(max = 20)
+  @Pattern(regexp = "^\\S+(\\s+\\S+)$")
+  String amendmentToTransportDocument,
 
   @Valid
   @NotEmpty(message = "consignmentItems are required.")


### PR DESCRIPTION
…utes

By default, if mapstruct cannot find a target attribute, it emits a compile time warning (that no one sees) and then continues with not mapping anything into that attribute.  With this change, (most) mappers have been configured to make this a compile error.

As a consequence:

 * Some target attributes have been fixed and are now mapped.
 * Most missing target attributes have now been explicitly declared as missing (along with a `FIXME` comment).
 * A few mappers are left at the default to close off the scope of this change (time constrained).

This will make it much harder for us to overlook mapping of attributes in the future and will make it less of a "Whack-a-mole" job to maintain the TO<-> DAO mapping in the BKG/eBL standard.