### PR TITLE
DT-297: Add final validdation (that we can support for now) of END party

### DIFF
--- a/edocumentation-domain/src/main/java/org/dcsa/edocumentation/domain/persistence/entity/DocumentParty.java
+++ b/edocumentation-domain/src/main/java/org/dcsa/edocumentation/domain/persistence/entity/DocumentParty.java
@@ -3,8 +3,7 @@ package org.dcsa.edocumentation.domain.persistence.entity;
 import lombok.*;
 
 import jakarta.persistence.*;
-import org.dcsa.edocumentation.domain.validations.AsyncShipperProvidedDataValidation;
-import org.dcsa.edocumentation.domain.validations.PseudoEnum;
+import org.dcsa.edocumentation.domain.validations.*;
 
 import java.util.UUID;
 
@@ -15,6 +14,8 @@ import java.util.UUID;
 @Setter(AccessLevel.PRIVATE)
 @Entity
 @Table(name = "document_party")
+@DocumentPartyEBLValidation(groups = EBLValidation.class)
+@DocumentPartyPaperBLValidation(groups = PaperBLValidation.class)
 public class DocumentParty {
 
   @Id

--- a/edocumentation-domain/src/main/java/org/dcsa/edocumentation/domain/validations/AbstractDocumentPartyValidator.java
+++ b/edocumentation-domain/src/main/java/org/dcsa/edocumentation/domain/validations/AbstractDocumentPartyValidator.java
@@ -1,0 +1,66 @@
+package org.dcsa.edocumentation.domain.validations;
+
+
+import jakarta.validation.ConstraintValidator;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import org.dcsa.edocumentation.domain.persistence.entity.DocumentParty;
+import org.dcsa.edocumentation.domain.persistence.entity.PartyIdentifyingCode;
+import org.dcsa.edocumentation.domain.persistence.entity.enums.DCSAResponsibleAgencyCode;
+import org.dcsa.edocumentation.domain.persistence.entity.enums.PartyFunction;
+
+public abstract class AbstractDocumentPartyValidator<A extends Annotation> implements ConstraintValidator<A, DocumentParty> {
+  private static final Set<String> PFS_ON_THE_EBL_REQUIRING_PID = Set.of(
+    PartyFunction.OS.name(),
+    PartyFunction.CN.name(),
+    PartyFunction.DDR.name(),
+    PartyFunction.DDS.name(),
+    PartyFunction.END.name()
+  );
+
+  protected void validateEPIPartyCode(ValidationState<DocumentParty> state, boolean isForEBL) {
+    var documentParty = state.getValue();
+    var partyFunction = documentParty.getPartyFunction();
+
+    int epiCodes = (int)Objects.requireNonNullElseGet(documentParty.getParty().getIdentifyingCodes(), List::<PartyIdentifyingCode>of)
+      .stream()
+      .filter(c -> c.getDcsaResponsibleAgencyCode() == DCSAResponsibleAgencyCode.EPI)
+      .count();
+    final int expectedAmountOfEPICodes = isForEBL && PFS_ON_THE_EBL_REQUIRING_PID.contains(partyFunction) ? 1 : 0;
+
+
+    if (epiCodes != expectedAmountOfEPICodes) {
+      state.invalidate();
+      String eBLType = isForEBL ? "an eBL" : "a paper B/L";
+      var constraintMessage = switch (epiCodes) {
+        case 0 -> "The document party with party function " + partyFunction + " must have an EPI party code when the B/L is " + eBLType + ".";
+        case 1 -> "The document party with party function " + partyFunction + " must not have any EPI party codes when the B/L is " + eBLType + ".";
+        default -> {
+          if (expectedAmountOfEPICodes == 0) {
+            String reason = PFS_ON_THE_EBL_REQUIRING_PID.contains(partyFunction)
+              ? " when the B/L is " + eBLType + "."
+              : ".";
+            yield "The document party with party function "
+              + partyFunction
+              + " had multiple EPI party codes, but it cannot have any" + reason;
+          }
+          yield "The document party with party function "
+            + partyFunction
+            + " had multiple EPI party codes, but must have exactly one when the B/L is " + eBLType + ".";
+        }
+      };
+      state.getContext().buildConstraintViolationWithTemplate(constraintMessage)
+        .addPropertyNode("documentParties")
+        .addConstraintViolation();
+      if (epiCodes == 0) {
+        state.getContext()
+          .buildConstraintViolationWithTemplate("The document party with party function " + partyFunction + " had multiple EPI party codes, but it can have at most one.")
+          .addPropertyNode("documentParties")
+          .addConstraintViolation();
+      }
+    }
+  }
+}

--- a/edocumentation-domain/src/main/java/org/dcsa/edocumentation/domain/validations/DocumentPartyEBLValidation.java
+++ b/edocumentation-domain/src/main/java/org/dcsa/edocumentation/domain/validations/DocumentPartyEBLValidation.java
@@ -1,0 +1,23 @@
+package org.dcsa.edocumentation.domain.validations;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = DocumentPartyEBLValidator.class)
+public @interface DocumentPartyEBLValidation {
+  String message() default "This attribute is not used (but required by the Validation API)";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/edocumentation-domain/src/main/java/org/dcsa/edocumentation/domain/validations/DocumentPartyEBLValidator.java
+++ b/edocumentation-domain/src/main/java/org/dcsa/edocumentation/domain/validations/DocumentPartyEBLValidator.java
@@ -1,0 +1,22 @@
+package org.dcsa.edocumentation.domain.validations;
+
+
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.Set;
+import org.dcsa.edocumentation.domain.persistence.entity.DocumentParty;
+import org.dcsa.edocumentation.domain.persistence.entity.enums.PartyFunction;
+
+public class DocumentPartyEBLValidator extends AbstractDocumentPartyValidator<DocumentPartyEBLValidation> {
+
+  @Override
+  public boolean isValid(DocumentParty value, ConstraintValidatorContext context) {
+    if (value == null) {
+      return true;
+    }
+    context.disableDefaultConstraintViolation();
+
+    var state = ValidationState.of(value, context);
+    validateEPIPartyCode(state, true);
+    return state.isValid();
+  }
+}

--- a/edocumentation-domain/src/main/java/org/dcsa/edocumentation/domain/validations/DocumentPartyPaperBLValidation.java
+++ b/edocumentation-domain/src/main/java/org/dcsa/edocumentation/domain/validations/DocumentPartyPaperBLValidation.java
@@ -1,0 +1,23 @@
+package org.dcsa.edocumentation.domain.validations;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = DocumentPartyPaperBLValidator.class)
+public @interface DocumentPartyPaperBLValidation {
+  String message() default "This attribute is not used (but required by the Validation API)";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/edocumentation-domain/src/main/java/org/dcsa/edocumentation/domain/validations/DocumentPartyPaperBLValidator.java
+++ b/edocumentation-domain/src/main/java/org/dcsa/edocumentation/domain/validations/DocumentPartyPaperBLValidator.java
@@ -1,0 +1,20 @@
+package org.dcsa.edocumentation.domain.validations;
+
+
+import jakarta.validation.ConstraintValidatorContext;
+import org.dcsa.edocumentation.domain.persistence.entity.DocumentParty;
+
+public class DocumentPartyPaperBLValidator extends AbstractDocumentPartyValidator<DocumentPartyPaperBLValidation> {
+
+  @Override
+  public boolean isValid(DocumentParty value, ConstraintValidatorContext context) {
+    if (value == null) {
+      return true;
+    }
+    context.disableDefaultConstraintViolation();
+
+    var state = ValidationState.of(value, context);
+    validateEPIPartyCode(state, false);
+    return state.isValid();
+  }
+}

--- a/edocumentation-domain/src/main/java/org/dcsa/edocumentation/domain/validations/EBLValidation.java
+++ b/edocumentation-domain/src/main/java/org/dcsa/edocumentation/domain/validations/EBLValidation.java
@@ -1,0 +1,3 @@
+package org.dcsa.edocumentation.domain.validations;
+
+public interface EBLValidation {}

--- a/edocumentation-domain/src/main/java/org/dcsa/edocumentation/domain/validations/PaperBLValidation.java
+++ b/edocumentation-domain/src/main/java/org/dcsa/edocumentation/domain/validations/PaperBLValidation.java
@@ -1,0 +1,3 @@
+package org.dcsa.edocumentation.domain.validations;
+
+public interface PaperBLValidation {}

--- a/edocumentation-domain/src/main/java/org/dcsa/edocumentation/domain/validations/ShippingInstructionValidator.java
+++ b/edocumentation-domain/src/main/java/org/dcsa/edocumentation/domain/validations/ShippingInstructionValidator.java
@@ -85,25 +85,22 @@ public class ShippingInstructionValidator implements ConstraintValidator<Shippin
   }
 
   private void validateStraightBL(ValidationState<ShippingInstruction> state) {
-    state.applyResult(validateLimitOnPartyFunction(state, PartyFunction.END, 0));
+    validateLimitOnPartyFunction(state, PartyFunction.END, 0);
     if (validateAtLeastOneOfIsPresent(state, Set.of(PartyFunction.CN.name(), PartyFunction.DDS.name()))) {
-      state.applyResult(validateAtMostOncePartyFunction(state, PartyFunction.CN));
-      state.applyResult(validateAtMostOncePartyFunction(state, PartyFunction.DDS));
-    } else {
-      state.invalidate();
+      validateAtMostOncePartyFunction(state, PartyFunction.CN);
+      validateAtMostOncePartyFunction(state, PartyFunction.DDS);
     }
   }
 
-
-  private boolean validateAtMostOncePartyFunction(ValidationState<ShippingInstruction> state, PartyFunction partyFunction) {
-    return validateLimitOnPartyFunction(state, partyFunction, 1);
+  private void validateAtMostOncePartyFunction(ValidationState<ShippingInstruction> state, PartyFunction partyFunction) {
+    validateLimitOnPartyFunction(state, partyFunction, 1);
   }
 
   private <T> Stream<T> nullSafeStream(Collection<T> c) {
     return c != null ? c.stream() : Stream.of();
   }
 
-  private boolean validateLimitOnPartyFunction(ValidationState<ShippingInstruction> state, PartyFunction partyFunction, int limit) {
+  private void validateLimitOnPartyFunction(ValidationState<ShippingInstruction> state, PartyFunction partyFunction, int limit) {
     var matches = nullSafeStream(state.getValue().getDocumentParties())
       .filter(p -> p.getPartyFunction().equals(partyFunction.name()))
       .count();
@@ -117,9 +114,7 @@ public class ShippingInstructionValidator implements ConstraintValidator<Shippin
         .addPropertyNode("documentParties")
         .addConstraintViolation();
       state.invalidate();
-      return false;
     }
-    return true;
   }
 
   private boolean validateAtLeastOneOfIsPresent(ValidationState<ShippingInstruction> state,
@@ -149,10 +144,8 @@ public class ShippingInstructionValidator implements ConstraintValidator<Shippin
 
   private void validateShipper(ValidationState<ShippingInstruction> state) {
     if (validateAtLeastOneOfIsPresent(state, Set.of(PartyFunction.OS.name(), PartyFunction.DDR.name()))) {
-      state.applyResult(validateAtMostOncePartyFunction(state, PartyFunction.OS));
-      state.applyResult(validateAtMostOncePartyFunction(state, PartyFunction.DDR));
-    } else {
-      state.invalidate();
+      validateAtMostOncePartyFunction(state, PartyFunction.OS);
+      validateAtMostOncePartyFunction(state, PartyFunction.DDR);
     }
   }
 

--- a/edocumentation-transfer-obj/src/main/java/org/dcsa/edocumentation/transferobjects/DocumentPartyTO.java
+++ b/edocumentation-transfer-obj/src/main/java/org/dcsa/edocumentation/transferobjects/DocumentPartyTO.java
@@ -5,7 +5,13 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 import lombok.Builder;
+import org.dcsa.edocumentation.transferobjects.validation.DocumentPartyTOEBLValidation;
+import org.dcsa.edocumentation.transferobjects.validation.DocumentPartyTOPaperBLValidation;
+import org.dcsa.edocumentation.transferobjects.validation.EBLValidation;
+import org.dcsa.edocumentation.transferobjects.validation.PaperBLValidation;
 
+@DocumentPartyTOEBLValidation(groups = EBLValidation.class)
+@DocumentPartyTOPaperBLValidation(groups = PaperBLValidation.class)
 public record DocumentPartyTO(
   @NotNull @Valid
   PartyTO party,

--- a/edocumentation-transfer-obj/src/main/java/org/dcsa/edocumentation/transferobjects/ShippingInstructionTO.java
+++ b/edocumentation-transfer-obj/src/main/java/org/dcsa/edocumentation/transferobjects/ShippingInstructionTO.java
@@ -12,15 +12,6 @@ import org.dcsa.skernel.infrastructure.transferobject.LocationTO;
 import org.dcsa.skernel.infrastructure.validation.RequiredIfFalse;
 import org.dcsa.skernel.infrastructure.validation.RestrictLocationTO;
 
-@RequiredIfFalse(
-  ifFalse = "isElectronic",
-  thenNotNull = {
-    "numberOfCopiesWithCharges",
-    "numberOfCopiesWithoutCharges",
-    "numberOfOriginalsWithCharges",
-    "numberOfOriginalsWithoutCharges"
-  }
-)
 public record ShippingInstructionTO(
   @Size(max = 100)
   @JsonProperty(access = JsonProperty.Access.READ_ONLY)

--- a/edocumentation-transfer-obj/src/main/java/org/dcsa/edocumentation/transferobjects/validation/AbstractDocumentPartyTOValidator.java
+++ b/edocumentation-transfer-obj/src/main/java/org/dcsa/edocumentation/transferobjects/validation/AbstractDocumentPartyTOValidator.java
@@ -1,0 +1,65 @@
+package org.dcsa.edocumentation.transferobjects.validation;
+
+
+import jakarta.validation.ConstraintValidator;
+import java.lang.annotation.Annotation;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import org.dcsa.edocumentation.transferobjects.DocumentPartyTO;
+import org.dcsa.edocumentation.transferobjects.PartyIdentifyingCodeTO;
+import org.dcsa.edocumentation.transferobjects.enums.DCSAResponsibleAgencyCode;
+import org.dcsa.edocumentation.transferobjects.enums.PartyFunction;
+
+public abstract class AbstractDocumentPartyTOValidator<A extends Annotation> implements ConstraintValidator<A, DocumentPartyTO> {
+  private static final Set<String> PFS_ON_THE_EBL_REQUIRING_PID = Set.of(
+    PartyFunction.OS.name(),
+    PartyFunction.CN.name(),
+    PartyFunction.DDR.name(),
+    PartyFunction.DDS.name(),
+    PartyFunction.END.name()
+  );
+
+  protected void validateEPIPartyCode(ValidationState<DocumentPartyTO> state, boolean isForEBL) {
+    var documentParty = state.getValue();
+    var partyFunction = documentParty.partyFunction();
+
+    int epiCodes = (int)Objects.requireNonNullElseGet(documentParty.party().identifyingCodes(), List::<PartyIdentifyingCodeTO>of)
+      .stream()
+      .filter(c -> c.dcsaResponsibleAgencyCode() == DCSAResponsibleAgencyCode.EPI)
+      .count();
+    final int expectedAmountOfEPICodes = isForEBL && PFS_ON_THE_EBL_REQUIRING_PID.contains(partyFunction) ? 1 : 0;
+
+
+    if (epiCodes != expectedAmountOfEPICodes) {
+      state.invalidate();
+      String eBLType = isForEBL ? "an eBL" : "a paper B/L";
+      var constraintMessage = switch (epiCodes) {
+        case 0 -> "The document party with party function " + partyFunction + " must have an EPI party code when the B/L is " + eBLType + ".";
+        case 1 -> "The document party with party function " + partyFunction + " must not have any EPI party codes when the B/L is " + eBLType + ".";
+        default -> {
+          if (expectedAmountOfEPICodes == 0) {
+            String reason = PFS_ON_THE_EBL_REQUIRING_PID.contains(partyFunction)
+              ? " when the B/L is " + eBLType + "."
+              : ".";
+            yield "The document party with party function "
+              + partyFunction
+              + " had multiple EPI party codes, but it cannot have any" + reason;
+          }
+          yield "The document party with party function "
+            + partyFunction
+            + " had multiple EPI party codes, but must have exactly one when the B/L is " + eBLType + ".";
+        }
+      };
+      state.getContext().buildConstraintViolationWithTemplate(constraintMessage)
+        .addPropertyNode("documentParties")
+        .addConstraintViolation();
+      if (epiCodes == 0) {
+        state.getContext()
+          .buildConstraintViolationWithTemplate("The document party with party function " + partyFunction + " had multiple EPI party codes, but it can have at most one.")
+          .addPropertyNode("documentParties")
+          .addConstraintViolation();
+      }
+    }
+  }
+}

--- a/edocumentation-transfer-obj/src/main/java/org/dcsa/edocumentation/transferobjects/validation/DocumentPartyTOEBLValidation.java
+++ b/edocumentation-transfer-obj/src/main/java/org/dcsa/edocumentation/transferobjects/validation/DocumentPartyTOEBLValidation.java
@@ -1,0 +1,23 @@
+package org.dcsa.edocumentation.transferobjects.validation;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = DocumentPartyTOEBLValidator.class)
+public @interface DocumentPartyTOEBLValidation {
+  String message() default "This attribute is not used (but required by the Validation API)";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/edocumentation-transfer-obj/src/main/java/org/dcsa/edocumentation/transferobjects/validation/DocumentPartyTOEBLValidator.java
+++ b/edocumentation-transfer-obj/src/main/java/org/dcsa/edocumentation/transferobjects/validation/DocumentPartyTOEBLValidator.java
@@ -1,0 +1,20 @@
+package org.dcsa.edocumentation.transferobjects.validation;
+
+
+import jakarta.validation.ConstraintValidatorContext;
+import org.dcsa.edocumentation.transferobjects.DocumentPartyTO;
+
+public class DocumentPartyTOEBLValidator extends AbstractDocumentPartyTOValidator<DocumentPartyTOEBLValidation> {
+
+  @Override
+  public boolean isValid(DocumentPartyTO value, ConstraintValidatorContext context) {
+    if (value == null) {
+      return true;
+    }
+    context.disableDefaultConstraintViolation();
+
+    var state = ValidationState.of(value, context);
+    validateEPIPartyCode(state, true);
+    return state.isValid();
+  }
+}

--- a/edocumentation-transfer-obj/src/main/java/org/dcsa/edocumentation/transferobjects/validation/DocumentPartyTOPaperBLValidation.java
+++ b/edocumentation-transfer-obj/src/main/java/org/dcsa/edocumentation/transferobjects/validation/DocumentPartyTOPaperBLValidation.java
@@ -1,0 +1,23 @@
+package org.dcsa.edocumentation.transferobjects.validation;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = DocumentPartyTOPaperBLValidator.class)
+public @interface DocumentPartyTOPaperBLValidation {
+  String message() default "This attribute is not used (but required by the Validation API)";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/edocumentation-transfer-obj/src/main/java/org/dcsa/edocumentation/transferobjects/validation/DocumentPartyTOPaperBLValidator.java
+++ b/edocumentation-transfer-obj/src/main/java/org/dcsa/edocumentation/transferobjects/validation/DocumentPartyTOPaperBLValidator.java
@@ -1,0 +1,20 @@
+package org.dcsa.edocumentation.transferobjects.validation;
+
+
+import jakarta.validation.ConstraintValidatorContext;
+import org.dcsa.edocumentation.transferobjects.DocumentPartyTO;
+
+public class DocumentPartyTOPaperBLValidator extends AbstractDocumentPartyTOValidator<DocumentPartyTOPaperBLValidation> {
+
+  @Override
+  public boolean isValid(DocumentPartyTO value, ConstraintValidatorContext context) {
+    if (value == null) {
+      return true;
+    }
+    context.disableDefaultConstraintViolation();
+
+    var state = ValidationState.of(value, context);
+    validateEPIPartyCode(state, false);
+    return state.isValid();
+  }
+}

--- a/edocumentation-transfer-obj/src/main/java/org/dcsa/edocumentation/transferobjects/validation/EBLValidation.java
+++ b/edocumentation-transfer-obj/src/main/java/org/dcsa/edocumentation/transferobjects/validation/EBLValidation.java
@@ -1,0 +1,3 @@
+package org.dcsa.edocumentation.transferobjects.validation;
+
+public interface EBLValidation {}

--- a/edocumentation-transfer-obj/src/main/java/org/dcsa/edocumentation/transferobjects/validation/PaperBLValidation.java
+++ b/edocumentation-transfer-obj/src/main/java/org/dcsa/edocumentation/transferobjects/validation/PaperBLValidation.java
@@ -1,0 +1,3 @@
+package org.dcsa.edocumentation.transferobjects.validation;
+
+public interface PaperBLValidation {}

--- a/edocumentation-transfer-obj/src/main/java/org/dcsa/edocumentation/transferobjects/validation/TransportDocumentTOValidation.java
+++ b/edocumentation-transfer-obj/src/main/java/org/dcsa/edocumentation/transferobjects/validation/TransportDocumentTOValidation.java
@@ -1,0 +1,23 @@
+package org.dcsa.edocumentation.transferobjects.validation;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = TransportDocumentTOValidator.class)
+public @interface TransportDocumentTOValidation {
+  String message() default "This attribute is not used (but required by the Validation API)";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/edocumentation-transfer-obj/src/main/java/org/dcsa/edocumentation/transferobjects/validation/TransportDocumentTOValidator.java
+++ b/edocumentation-transfer-obj/src/main/java/org/dcsa/edocumentation/transferobjects/validation/TransportDocumentTOValidator.java
@@ -1,0 +1,168 @@
+package org.dcsa.edocumentation.transferobjects.validation;
+
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.dcsa.edocumentation.transferobjects.DocumentPartyTO;
+import org.dcsa.edocumentation.transferobjects.TransportDocumentTO;
+import org.dcsa.edocumentation.transferobjects.enums.EblDocumentStatus;
+import org.dcsa.edocumentation.transferobjects.enums.PartyFunction;
+
+public class TransportDocumentTOValidator implements ConstraintValidator<TransportDocumentTOValidation, TransportDocumentTO> {
+
+  @Override
+  public boolean isValid(TransportDocumentTO value, ConstraintValidatorContext context) {
+    if (value == null) {
+      return true;
+    }
+    context.disableDefaultConstraintViolation();
+
+    var state = ValidationState.of(value, context);
+    validateDates(state);
+    validateShipper(state);
+    validateQuotationReference(state);
+    if (value.isToOrder() == Boolean.TRUE) {
+      validateNegotiableBL(state);
+    } else {
+      validateStraightBL(state);
+    }
+    return state.isValid();
+  }
+
+  private void validateQuotationReference(ValidationState<TransportDocumentTO> state) {
+    var td = state.getValue();
+    if (td.contractQuotationReference() == null) {
+      var hasSco = nullSafeStream(td.documentParties())
+        .filter(p -> p.partyFunction()
+        .equals(PartyFunction.SCO.name()))
+        .count();
+      if (state.applyResult(hasSco > 0)) {
+        state.getContext()
+          .buildConstraintViolationWithTemplate("Without a contractQuotationReference, a service contract owner (Party Function: SCO) must be present")
+          .addConstraintViolation();
+      }
+    }
+  }
+
+  private void validateDates(ValidationState<TransportDocumentTO> state) {
+    var td = state.getValue();
+    var context = state.getContext();
+    var issueDate = td.issueDate();
+    if (issueDate == null && !state.applyResult(td.documentStatus() == EblDocumentStatus.DRFT)) {
+      context.buildConstraintViolationWithTemplate("The issueDate is mandatory for documents that have been issued (documentStatus != DRFT)")
+        .addPropertyNode("issueDate")
+        .addConstraintViolation();
+    }
+    // TODO: Check issueDate is not in the future
+    if (!state.applyResult(td.receivedForShipmentDate() != null ^ td.shippedOnBoardDate() != null)) {
+      context.buildConstraintViolationWithTemplate("The transport document must have either receivedForShipmentDate or shippedOnBoardDate. However, they are mutually exclusive.")
+        .addConstraintViolation();
+      return;
+    }
+    if (issueDate == null) {
+      return;
+    }
+    var compareDate = td.shippedOnBoardDate();
+    var attrName = "shippedOnBoardDate";
+    if (compareDate == null) {
+      compareDate = td.receivedForShipmentDate();
+      attrName = "receivedForShipmentDate";
+    }
+    assert compareDate != null;
+    if (compareDate.isAfter(issueDate)) {
+      context.buildConstraintViolationWithTemplate("The " + attrName + " must be before or equal to the issueDate on an issued document")
+          .addPropertyNode(attrName)
+          .addConstraintViolation();
+      state.invalidate();
+    }
+  }
+
+  private void validateStraightBL(ValidationState<TransportDocumentTO> state) {
+    validateLimitOnPartyFunction(state, PartyFunction.END, 0);
+    if (validateAtLeastOneOfIsPresent(state, Set.of(PartyFunction.CN.name(), PartyFunction.DDS.name()))) {
+      validateAtMostOncePartyFunction(state, PartyFunction.CN);
+      validateAtMostOncePartyFunction(state, PartyFunction.DDS);
+      validateMutuallyExclusivePartyFunctions(state, Set.of(PartyFunction.CN.name(), PartyFunction.DDS.name()));
+    }
+  }
+
+
+  private void validateAtMostOncePartyFunction(ValidationState<TransportDocumentTO> state, PartyFunction partyFunction) {
+    validateLimitOnPartyFunction(state, partyFunction, 1);
+  }
+
+  private <T> Stream<T> nullSafeStream(Collection<T> c) {
+    return c != null ? c.stream() : Stream.of();
+  }
+
+  private void validateMutuallyExclusivePartyFunctions(ValidationState<TransportDocumentTO> state, Set<String> partyFunctions) {
+    var matches = nullSafeStream(state.getValue().documentParties())
+      .map(DocumentPartyTO::partyFunction)
+      .filter(partyFunctions::contains)
+      .distinct()
+      .toList();
+    if (matches.size() < 2) {
+      return;
+    }
+    String names = String.join(", ", matches);
+    String message = "The following party functions cannot be used together: " + names;
+    state.getContext().buildConstraintViolationWithTemplate(message)
+      .addPropertyNode("documentParties")
+      .addConstraintViolation();
+    state.invalidate();
+  }
+
+  private void validateLimitOnPartyFunction(ValidationState<TransportDocumentTO> state, PartyFunction partyFunction, int limit) {
+    var matches = nullSafeStream(state.getValue().documentParties())
+      .filter(p -> p.partyFunction().equals(partyFunction.name()))
+      .count();
+    if (matches > limit) {
+      String messageTemplate = switch (limit) {
+        case 0 -> "The party function " + partyFunction.name() + " cannot be used on this SI.";
+        case 1 -> "There can only be at most one party with the partyFunction " + partyFunction.name();
+        default -> "There can only be at most " + limit + " parties with the partyFunction " + partyFunction.name();
+      };
+      state.getContext().buildConstraintViolationWithTemplate(messageTemplate)
+        .addPropertyNode("documentParties")
+        .addConstraintViolation();
+      state.invalidate();
+    }
+  }
+
+  private boolean validateAtLeastOneOfIsPresent(ValidationState<TransportDocumentTO> state,
+                                                Set<String> partyFunctions) {
+    var matches = nullSafeStream(state.getValue().documentParties())
+      .filter(p -> partyFunctions.contains(p.partyFunction()))
+      .count();
+    if (matches < 1) {
+      state.getContext().buildConstraintViolationWithTemplate(
+        "This SI requires at least one of the following party functions to be present: " +
+          String.join(", ", partyFunctions.stream().toList())
+      ).addPropertyNode("documentParties")
+        .addConstraintViolation();
+      state.invalidate();
+      return false;
+    }
+    return true;
+  }
+
+  private void validateNegotiableBL(ValidationState<TransportDocumentTO> state) {
+    validateAtMostOncePartyFunction(state, PartyFunction.END);
+
+    validateLimitOnPartyFunction(state, PartyFunction.OS, 0);
+    validateLimitOnPartyFunction(state, PartyFunction.DDR, 0);
+  }
+
+
+  private void validateShipper(ValidationState<TransportDocumentTO> state) {
+    if (validateAtLeastOneOfIsPresent(state, Set.of(PartyFunction.OS.name(), PartyFunction.DDR.name()))) {
+      validateAtMostOncePartyFunction(state, PartyFunction.OS);
+      validateAtMostOncePartyFunction(state, PartyFunction.DDR);
+      validateMutuallyExclusivePartyFunctions(state, Set.of(PartyFunction.OS.name(), PartyFunction.DDR.name()));
+    }
+  }
+}

--- a/edocumentation-transfer-obj/src/main/java/org/dcsa/edocumentation/transferobjects/validation/ValidationState.java
+++ b/edocumentation-transfer-obj/src/main/java/org/dcsa/edocumentation/transferobjects/validation/ValidationState.java
@@ -1,4 +1,4 @@
-package org.dcsa.edocumentation.domain.validations;
+package org.dcsa.edocumentation.transferobjects.validation;
 
 import jakarta.validation.ConstraintValidatorContext;
 import lombok.Getter;

--- a/postman_collection.json
+++ b/postman_collection.json
@@ -48,9 +48,13 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test('Body contains 0 or more items', () => {\r",
-											"    pm.expect(pm.response.json().length).to.equal(0);\r",
-											"});"
+											"pm.test('All matches must have correct status', () => {\r",
+											"    const response = pm.response.json()\r",
+											"    for (let i = 0; i < response.length ; i++) {\r",
+											"        pm.expect(response[i].documentStatus).to.equal(\"CMPL\");\r",
+											"    }\r",
+											"});\r",
+											""
 										],
 										"type": "text/javascript"
 									}
@@ -375,8 +379,11 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test('Body contains 0 or more items', () => {\r",
-											"    pm.expect(pm.response.json().length).to.equal(0);\r",
+											"pm.test('All matches must have correct status', () => {\r",
+											"    const response = pm.response.json()\r",
+											"    for (let i = 0; i < response.length ; i++) {\r",
+											"        pm.expect(response[i].documentStatus).to.equal(\"CMPL\");\r",
+											"    }\r",
 											"});"
 										],
 										"type": "text/javascript"
@@ -5968,7 +5975,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\r\n    \"isShippedOnBoardType\": true,\r\n    \"isElectronic\": true,\r\n    \"isToOrder\": false,\r\n    \"displayedNameForPortOfLoad\": [\r\n            \"Port of Rotterdam\"\r\n        ],\r\n    \"customsReferences\": [\r\n        {\r\n            \"type\": \"CERS\",\r\n            \"countryCode\": \"CA\",\r\n            \"value\": \"12345678\"\r\n        }\r\n    ],\r\n    \"consignmentItems\": [\r\n        {\r\n            \"HSCodes\": [\"411510\"],\r\n            \"carrierBookingReference\": \"{{CARRIER_BOOKING_REFERENCE}}\",\r\n            \"weight\": 120.4,\r\n            \"weightUnit\": \"KGM\",\r\n            \"descriptionOfGoods\": \"The goods!\",\r\n            \"cargoItems\": [\r\n                {\r\n                    \"equipmentReference\": \"BMOU2149612\",\r\n                    \"weight\": 120.3,\r\n                    \"weightUnit\": \"KGM\",\r\n                    \"shippingMarks\": [\"bar\"]\r\n                }\r\n            ],\r\n            \"customsReferences\": [\r\n                {\r\n                    \"type\": \"CERS\",\r\n                    \"countryCode\": \"CA\",\r\n                    \"value\": \"12345678\"\r\n                }\r\n            ]\r\n        }\r\n    ],\r\n    \"utilizedTransportEquipments\": [\r\n        {\r\n            \"equipmentReference\": \"BMOU2149612\",\r\n            \"cargoGrossWeight\": 120.3,\r\n            \"cargoGrossWeightUnit\": \"KGM\",\r\n            \"isShipperOwned\": false,\r\n            \"seals\": [\r\n                {\r\n                    \"number\": \"12345\",\r\n                    \"source\": \"CAR\",\r\n                    \"type\": \"BLT\"\r\n                }\r\n            ],\r\n            \"customsReferences\": [\r\n                {\r\n                    \"type\": \"CERS\",\r\n                    \"countryCode\": \"CA\",\r\n                    \"value\": \"12345678\"\r\n                }\r\n            ]\r\n        }\r\n    ],\r\n    \"documentParties\": [\r\n        {\r\n            \"party\": {\r\n                \"partyName\": \"foo party\",\r\n                \"address\": {\r\n                    \"name\": \"foo address name\"\r\n                },\r\n                \"partyContactDetails\": [\r\n                    {\r\n                        \"name\": \"partycontact details\",\r\n                        \"email\": \"someone@foo.example.com\"\r\n                    }\r\n                ]\r\n            },\r\n            \"partyFunction\": \"CN\",\r\n            \"displayedAddress\": [\r\n                \"foo\"\r\n            ],\r\n            \"isToBeNotified\": false\r\n        },\r\n        {\r\n            \"party\": {\r\n                \"partyName\": \"bar party\",\r\n                \"address\": {\r\n                    \"name\": \"bar address name\"\r\n                },\r\n                \"partyContactDetails\": [\r\n                    {\r\n                        \"name\": \"partycontact details\",\r\n                        \"email\": \"someone@bar.example.com\"\r\n                    }\r\n                ]\r\n            },\r\n            \"partyFunction\": \"OS\",\r\n            \"displayedAddress\": [\r\n                \"bar\"\r\n            ],\r\n            \"isToBeNotified\": false\r\n        }\r\n    ],\r\n    \"references\": [\r\n        {\r\n            \"type\": \"AAO\",\r\n            \"value\": \"foo reference\"\r\n        }\r\n    ]\r\n}",
+											"raw": "{\r\n    \"isShippedOnBoardType\": true,\r\n    \"isElectronic\": true,\r\n    \"isToOrder\": false,\r\n    \"displayedNameForPortOfLoad\": [\r\n            \"Port of Rotterdam\"\r\n    ],\r\n    \"customsReferences\": [\r\n        {\r\n            \"type\": \"CERS\",\r\n            \"countryCode\": \"CA\",\r\n            \"value\": \"12345678\"\r\n        }\r\n    ],\r\n    \"consignmentItems\": [\r\n        {\r\n            \"HSCodes\": [\"411510\"],\r\n            \"carrierBookingReference\": \"{{CARRIER_BOOKING_REFERENCE}}\",\r\n            \"weight\": 120.4,\r\n            \"weightUnit\": \"KGM\",\r\n            \"descriptionOfGoods\": \"The goods!\",\r\n            \"cargoItems\": [\r\n                {\r\n                    \"equipmentReference\": \"BMOU2149612\",\r\n                    \"weight\": 120.3,\r\n                    \"weightUnit\": \"KGM\",\r\n                    \"shippingMarks\": [\"bar\"]\r\n                }\r\n            ],\r\n            \"customsReferences\": [\r\n                {\r\n                    \"type\": \"CERS\",\r\n                    \"countryCode\": \"CA\",\r\n                    \"value\": \"12345678\"\r\n                }\r\n            ]\r\n        }\r\n    ],\r\n    \"utilizedTransportEquipments\": [\r\n        {\r\n            \"equipmentReference\": \"BMOU2149612\",\r\n            \"cargoGrossWeight\": 120.3,\r\n            \"cargoGrossWeightUnit\": \"KGM\",\r\n            \"isShipperOwned\": false,\r\n            \"seals\": [\r\n                {\r\n                    \"number\": \"12345\",\r\n                    \"source\": \"CAR\",\r\n                    \"type\": \"BLT\"\r\n                }\r\n            ],\r\n            \"customsReferences\": [\r\n                {\r\n                    \"type\": \"CERS\",\r\n                    \"countryCode\": \"CA\",\r\n                    \"value\": \"12345678\"\r\n                }\r\n            ]\r\n        }\r\n    ],\r\n    \"documentParties\": [\r\n        {\r\n            \"party\": {\r\n                \"partyName\": \"foo party\",\r\n                \"address\": {\r\n                    \"name\": \"foo address name\"\r\n                },\r\n                \"partyContactDetails\": [\r\n                    {\r\n                        \"name\": \"partycontact details\",\r\n                        \"email\": \"someone@foo.example.com\"\r\n                    }\r\n                ],\r\n                \"identifyingCodes\": [\r\n                    {\r\n                        \"DCSAResponsibleAgencyCode\": \"EPI\",\r\n                        \"partyCode\": \"foo@platform1.example.com\"\r\n                    }\r\n                ]\r\n            },\r\n            \"partyFunction\": \"CN\",\r\n            \"displayedAddress\": [\r\n                \"foo\"\r\n            ],\r\n            \"isToBeNotified\": false\r\n        },\r\n        {\r\n            \"party\": {\r\n                \"partyName\": \"bar party\",\r\n                \"address\": {\r\n                    \"name\": \"bar address name\"\r\n                },\r\n                \"partyContactDetails\": [\r\n                    {\r\n                        \"name\": \"partycontact details\",\r\n                        \"email\": \"someone@bar.example.com\"\r\n                    }\r\n                ],\r\n                \"identifyingCodes\": [\r\n                    {\r\n                        \"DCSAResponsibleAgencyCode\": \"EPI\",\r\n                        \"partyCode\": \"bar@platform2.example.com\"\r\n                    }\r\n                ]\r\n            },\r\n            \"partyFunction\": \"OS\",\r\n            \"displayedAddress\": [\r\n                \"bar\"\r\n            ],\r\n            \"isToBeNotified\": false\r\n        }\r\n    ],\r\n    \"references\": [\r\n        {\r\n            \"type\": \"AAO\",\r\n            \"value\": \"foo reference\"\r\n        }\r\n    ]\r\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -6428,6 +6435,10 @@
 		},
 		{
 			"key": "CARRIER_BOOKING_REQUEST_REFERENCE",
+			"value": ""
+		},
+		{
+			"key": "DOCUMENT_STATUSSES",
 			"value": ""
 		}
 	]


### PR DESCRIPTION
Additionally:

 * Refactor and strengthen the validation of SI and the TO version of the TO.
 * Self-check the draft TDs that the RI generates to ensure the RI would accept its own draft.  When this validation fails, we throw an assertion error, since we should not generate TDs that the RI would not accept ourselves. It is worth noting that the TD level validation checks more than the SI async validation, so there is a currently a potential gap for the draft TD to be invalid.