### PR TITLE
Remove unnecessary `Commodity` when creating `ConsignmentItem`

### DIFF
--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/StuffingService.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/StuffingService.java
@@ -1,8 +1,10 @@
 package org.dcsa.edocumentation.service;
 
+import jakarta.transaction.Transactional;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.dcsa.edocumentation.domain.persistence.entity.*;
-import org.dcsa.edocumentation.domain.persistence.repository.CommodityRepository;
 import org.dcsa.edocumentation.domain.persistence.repository.ConsignementItemRepository;
 import org.dcsa.edocumentation.domain.persistence.repository.ShipmentRepository;
 import org.dcsa.edocumentation.service.mapping.CargoItemMapper;
@@ -12,10 +14,6 @@ import org.dcsa.edocumentation.transferobjects.ConsignmentItemTO;
 import org.dcsa.skernel.errors.exceptions.ConcreteRequestErrorMessageException;
 import org.springframework.stereotype.Service;
 
-import jakarta.transaction.Transactional;
-import java.util.List;
-import java.util.Map;
-
 @Service
 @RequiredArgsConstructor
 public class StuffingService {
@@ -24,7 +22,6 @@ public class StuffingService {
   private final ConsignmentItemMapper consignmentItemMapper;
   private final ConsignementItemRepository consignementItemRepository;
   private final CargoItemMapper cargoItemMapper;
-  private final CommodityRepository commodityRepository;
 
   @Transactional(Transactional.TxType.MANDATORY)
   public void createStuffing(
@@ -38,14 +35,7 @@ public class StuffingService {
                 consignmentItemTO -> {
                   ConsignmentItem consignmentItem = consignmentItemMapper.toDAO(consignmentItemTO);
                   Shipment shipment = addShipment(consignmentItemTO.carrierBookingReference());
-                  Commodity commodity = commodityRepository.save(Commodity.builder()
-                    .booking(shipment.getBooking())
-                    .commodityType(consignmentItem.getDescriptionOfGoods())
-                    .hsCodes(consignmentItemTO.hsCodes())
-                    .build()
-                  );
                   return consignmentItem.toBuilder()
-                      .commodity(commodity)
                       .shipment(shipment)
                       .shippingInstruction(shippingInstruction)
                       .cargoItems(

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/ConsignmentItemMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/ConsignmentItemMapper.java
@@ -30,13 +30,8 @@ public interface ConsignmentItemMapper {
     return shipment.getCarrierBookingReference();
   }
 
-  default List<String> mapCommodityToHsCodes(Commodity commodity) {
-    return commodity.getHsCodes();
-  }
-
 
   @Mapping(source = "shipment", target = "carrierBookingReference")
-  @Mapping(source = "commodity", target = "hsCodes")
   @Mapping(target = "weight", ignore = true)  // FIXME: Align DAO/TD or verify it is not necessary and remove FIXME
   @Mapping(target = "weightUnit", ignore = true)  // FIXME: Align DAO/TD or verify it is not necessary and remove FIXME
   @Mapping(target = "volume", ignore = true)  // FIXME: Align DAO/TD or verify it is not necessary and remove FIXME

--- a/edocumentation-service/src/test/java/org/dcsa/edocumentation/service/StuffingServiceTest.java
+++ b/edocumentation-service/src/test/java/org/dcsa/edocumentation/service/StuffingServiceTest.java
@@ -1,11 +1,17 @@
 package org.dcsa.edocumentation.service;
 
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.dcsa.edocumentation.datafactories.ConsignmentItemDataFactory;
 import org.dcsa.edocumentation.datafactories.ShipmentDataFactory;
 import org.dcsa.edocumentation.datafactories.ShippingInstructionDataFactory;
 import org.dcsa.edocumentation.datafactories.UtilizedTransportEquipmentEquipmentDataFactory;
 import org.dcsa.edocumentation.domain.persistence.entity.*;
-import org.dcsa.edocumentation.domain.persistence.repository.CommodityRepository;
 import org.dcsa.edocumentation.domain.persistence.repository.ConsignementItemRepository;
 import org.dcsa.edocumentation.domain.persistence.repository.ShipmentRepository;
 import org.dcsa.edocumentation.service.mapping.CargoItemMapper;
@@ -22,18 +28,9 @@ import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 @ExtendWith(MockitoExtension.class)
 class StuffingServiceTest {
   @Mock private ShipmentRepository shipmentRepository;
-  @Mock private CommodityRepository commodityRepository;
   @Mock private ConsignementItemRepository consignementItemRepository;
 
 


### PR DESCRIPTION
This code is from a time where the `hsCodes` was always on the `Commodity`. However, a later clarification meant that the consignment item could have a distinct valeu for `hsCodes` (usually a precision of the commodity `hsCodes`)