### PR TITLE
Remove unnecessary DB link between UtilizedTransportEquipment and RequestedEquipmentGroup

### DIFF
--- a/edocumentation-domain/src/main/java/org/dcsa/edocumentation/domain/persistence/entity/RequestedEquipmentGroup.java
+++ b/edocumentation-domain/src/main/java/org/dcsa/edocumentation/domain/persistence/entity/RequestedEquipmentGroup.java
@@ -55,12 +55,6 @@ public class RequestedEquipmentGroup {
 
   @ToString.Exclude
   @EqualsAndHashCode.Exclude
-  @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-  @JoinColumn(name = "requested_equipment_group_id")
-  private Set<UtilizedTransportEquipment> utilizedTransportEquipments;
-
-  @ToString.Exclude
-  @EqualsAndHashCode.Exclude
   @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
   @JoinColumn(name = "commodity_id")
   private Commodity commodity;

--- a/edocumentation-domain/src/main/java/org/dcsa/edocumentation/domain/persistence/entity/UtilizedTransportEquipment.java
+++ b/edocumentation-domain/src/main/java/org/dcsa/edocumentation/domain/persistence/entity/UtilizedTransportEquipment.java
@@ -40,12 +40,6 @@ public class UtilizedTransportEquipment {
 
   @ToString.Exclude
   @EqualsAndHashCode.Exclude
-  @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-  @JoinColumn(name = "requested_equipment_group_id")
-  private RequestedEquipmentGroup requestedEquipmentGroup;
-
-  @ToString.Exclude
-  @EqualsAndHashCode.Exclude
   @OneToMany(cascade = CascadeType.ALL)
   @JoinColumn(name = "utilized_transport_equipment_id", nullable = false)
   private Set<@Valid Seal> seals;

--- a/edocumentation-domain/src/main/resources/db/migration/V3_0__dcsa_im_v3.sql
+++ b/edocumentation-domain/src/main/resources/db/migration/V3_0__dcsa_im_v3.sql
@@ -417,8 +417,7 @@ CREATE TABLE utilized_transport_equipment (
     equipment_reference varchar(15) NOT NULL REFERENCES equipment (equipment_reference),
     cargo_gross_weight real NULL,
     cargo_gross_weight_unit varchar(3) NULL REFERENCES unit_of_measure(unit_of_measure_code) CHECK (cargo_gross_weight_unit IN ('KGM','LBR')),
-    is_shipper_owned boolean NOT NULL,
-    requested_equipment_group_id uuid NULL REFERENCES requested_equipment_group (id)
+    is_shipper_owned boolean NOT NULL
 );
 
 -- Supporting FK constraints

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/RequestedEquipmentGroupService.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/RequestedEquipmentGroupService.java
@@ -1,23 +1,20 @@
 package org.dcsa.edocumentation.service;
 
+import jakarta.transaction.Transactional;
+import jakarta.transaction.Transactional.TxType;
+import java.util.Collection;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.dcsa.edocumentation.domain.persistence.entity.Booking;
 import org.dcsa.edocumentation.domain.persistence.entity.Commodity;
 import org.dcsa.edocumentation.domain.persistence.entity.Equipment;
 import org.dcsa.edocumentation.domain.persistence.entity.RequestedEquipmentGroup;
-import org.dcsa.edocumentation.domain.persistence.entity.UtilizedTransportEquipment;
 import org.dcsa.edocumentation.domain.persistence.repository.RequestedEquipmentGroupRepository;
 import org.dcsa.edocumentation.domain.persistence.repository.UtilizedTransportEquipmentRepository;
 import org.dcsa.edocumentation.service.mapping.EquipmentMapper;
 import org.dcsa.edocumentation.service.mapping.RequestedEquipmentGroupMapper;
 import org.dcsa.edocumentation.transferobjects.RequestedEquipmentTO;
 import org.springframework.stereotype.Service;
-
-import jakarta.transaction.Transactional;
-import jakarta.transaction.Transactional.TxType;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -38,41 +35,21 @@ public class RequestedEquipmentGroupService {
     Commodity commodity
   ) {
     if (requestedEquipments != null && !requestedEquipments.isEmpty()) {
-      // Load all Equipments
-      Map<String, Equipment> equipments =
-        equipmentService.resolveEquipments(
+      // Resolve all Equipments
+      equipmentService.resolveEquipments(
           requestedEquipments,
           RequestedEquipmentTO::isShipperOwned,
           equipmentMapper::toNonNullableDTOStream);
 
       // Create and save RequestedEquipments
-      requestedEquipments.forEach(re -> {
-        RequestedEquipmentGroup reg = requestedEquipmentGroupRepository.save(
-          requestedEquipmentGroupMapper.toDAO(
-            re,
-            booking,
-            activeReeferSettingsService.createActiveReeferSettings(re.activeReeferSettings()),
-            commodity
-          )
-        );
-
-        createUtilizedTransports(reg, re.equipmentReferences(), equipments);
-      });
-    }
-  }
-
-  private void createUtilizedTransports(RequestedEquipmentGroup reg, List<String> equipmentReferences, Map<String, Equipment> equipments) {
-    if (equipmentReferences != null && !equipmentReferences.isEmpty()) {
-      utilizedTransportEquipmentRepository.saveAll(
-        equipmentReferences.stream()
-          .map(reference -> UtilizedTransportEquipment.builder()
-            .requestedEquipmentGroup(reg)
-            .equipment(equipments.get(reference))
-            .isShipperOwned(reg.getIsShipperOwned())
-            .build()
-          )
-          .toList()
-      );
+      requestedEquipments.forEach(re -> requestedEquipmentGroupRepository.save(
+        requestedEquipmentGroupMapper.toDAO(
+          re,
+          booking,
+          activeReeferSettingsService.createActiveReeferSettings(re.activeReeferSettings()),
+          commodity
+        )
+      ));
     }
   }
 }

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/RequestedEquipmentGroupMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/RequestedEquipmentGroupMapper.java
@@ -25,8 +25,6 @@ public interface RequestedEquipmentGroupMapper {
   @Mapping(source = "requestedEquipment.isoEquipmentCode", target = "isoEquipmentCode")
   @Mapping(source = "requestedEquipment.units", target = "units")
   @Mapping(source = "commodity", target = "commodity")
-  // FIXME: The RequestedEquipmentGroup should probably not have a utilizedTransportEquipments
-  @Mapping(target = "utilizedTransportEquipments", ignore = true)
   RequestedEquipmentGroup toDAO(
     RequestedEquipmentTO requestedEquipment,
     Booking booking,

--- a/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/UtilizedTransportEquipmentMapper.java
+++ b/edocumentation-service/src/main/java/org/dcsa/edocumentation/service/mapping/UtilizedTransportEquipmentMapper.java
@@ -20,7 +20,6 @@ public interface UtilizedTransportEquipmentMapper {
   @Mapping(source = "utilizedTransportEquipmentTO.isShipperOwned", target = "isShipperOwned")
   @Mapping(source = "equipment", target = "equipment")
   @Mapping(target = "id", ignore = true)
-  @Mapping(target = "requestedEquipmentGroup", ignore = true)
   UtilizedTransportEquipment toDAO(UtilizedTransportEquipmentTO utilizedTransportEquipmentTO, Equipment equipment);
 
   @Mapping(target = "equipmentReference", expression = "java(null)")  // FIXME: In TD, always absent. In other cases, conditional on "isSOC"!

--- a/edocumentation-service/src/test/java/org/dcsa/edocumentation/service/RequestedEquipmentGroupServiceTest.java
+++ b/edocumentation-service/src/test/java/org/dcsa/edocumentation/service/RequestedEquipmentGroupServiceTest.java
@@ -1,5 +1,14 @@
 package org.dcsa.edocumentation.service;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
 import org.dcsa.edocumentation.datafactories.BookingDataFactory;
 import org.dcsa.edocumentation.datafactories.CommodityDataFactory;
 import org.dcsa.edocumentation.datafactories.EquipmentDataFactory;
@@ -8,7 +17,6 @@ import org.dcsa.edocumentation.domain.persistence.entity.Booking;
 import org.dcsa.edocumentation.domain.persistence.entity.Commodity;
 import org.dcsa.edocumentation.domain.persistence.entity.RequestedEquipmentGroup;
 import org.dcsa.edocumentation.domain.persistence.repository.RequestedEquipmentGroupRepository;
-import org.dcsa.edocumentation.domain.persistence.repository.UtilizedTransportEquipmentRepository;
 import org.dcsa.edocumentation.service.mapping.EquipmentMapper;
 import org.dcsa.edocumentation.service.mapping.RequestedEquipmentGroupMapper;
 import org.dcsa.edocumentation.transferobjects.RequestedEquipmentTO;
@@ -21,22 +29,11 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Collections;
-import java.util.List;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 @ExtendWith(MockitoExtension.class)
 public class RequestedEquipmentGroupServiceTest {
   @Mock private EquipmentService equipmentService;
   @Mock private ActiveReeferSettingsService activeReeferSettingsService;
   @Mock private RequestedEquipmentGroupRepository requestedEquipmentGroupRepository;
-  @Mock private UtilizedTransportEquipmentRepository utilizedTransportEquipmentRepository;
   @Spy private RequestedEquipmentGroupMapper requestedEquipmentGroupMapper = Mappers.getMapper(RequestedEquipmentGroupMapper.class);
   @Spy private EquipmentMapper equipmentMapper = Mappers.getMapper(EquipmentMapper.class);
 
@@ -44,7 +41,7 @@ public class RequestedEquipmentGroupServiceTest {
 
   @BeforeEach
   public void resetMocks() {
-    reset(equipmentService, activeReeferSettingsService, requestedEquipmentGroupRepository, utilizedTransportEquipmentRepository);
+    reset(equipmentService, activeReeferSettingsService, requestedEquipmentGroupRepository);
   }
 
   @Test
@@ -82,6 +79,5 @@ public class RequestedEquipmentGroupServiceTest {
     verify(equipmentService).resolveEquipments(eq(List.of(requestedEquipmentTO)), any(), any());
     verify(requestedEquipmentGroupRepository).save(expectedGroup);
     verify(activeReeferSettingsService).createActiveReeferSettings(requestedEquipmentTO.activeReeferSettings());
-    verify(utilizedTransportEquipmentRepository).saveAll(any());
   }
 }


### PR DESCRIPTION
Currently, we just fed garbage down that pipe when creating the booking and then left it to rot in the database.  We do not need more garbage rotting our database, and removing the code means there is one less spinning wheel dodge when rewriting the requested equipment <-> commodity relation.